### PR TITLE
[ADD] lifecycle willStart to update Customers

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
@@ -47,8 +47,11 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
             };
             this.updateClientList = debounce(this.updateClientList, 70);
         }
-
+        
         // Lifecycle hooks
+        async willStart(){
+            await this.env.pos.load_new_partners().catch(r=>console.log("Partners where not updated",r));
+        }
         back() {
             if(this.state.detailIsShown) {
                 this.state.detailIsShown = false;


### PR DESCRIPTION
Added a new willstart function calling load_new_partners from db so customers are updated whenever you get into the customer selection, this way POS is fully synced to the db and also fixes a bug where loyalty points are not correctly updated

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
