### PR TITLE
[FIX] pos customer correctly syncs now

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
@@ -47,8 +47,11 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
             };
             this.updateClientList = debounce(this.updateClientList, 70);
         }
-
+        
         // Lifecycle hooks
+        async willStart(){
+            await this.env.pos.load_new_partners().catch(r=>console.log("Partners where not updated",r));
+        }
         back() {
             if(this.state.detailIsShown) {
                 this.state.detailIsShown = false;

--- a/addons/point_of_sale/static/src/js/db.js
+++ b/addons/point_of_sale/static/src/js/db.js
@@ -241,7 +241,7 @@ var PosDB = core.Class.extend({
     },
     add_partners: function(partners){
         var updated_count = 0;
-        var new_write_date = '';
+        var new_write_date = new Date().toISOString().replace(/(.*T.*)(.*Z.*)$/, '');
         var partner;
         for(var i = 0, len = partners.length; i < len; i++){
             partner = partners[i];
@@ -252,6 +252,7 @@ var PosDB = core.Class.extend({
                     this.partner_by_id[partner.id] &&
                     new Date(local_partner_date).getTime() + 1000 >=
                     new Date(dist_partner_date).getTime() ) {
+                //This is working as intended, above comment should be erased as it leaves doubt to future readers, 
                 // FIXME: The write_date is stored with milisec precision in the database
                 // but the dates we get back are only precise to the second. This means when
                 // you read partners modified strictly after time X, you get back partners that were


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Between other things, when in POS you want to select a customer, odoo doesnt show updated data, instead keeps data synced from first time it was loaded, this cause several errors and possible bugs, one of them is that when using in enterprise version pos_loyalty to add loyalty programs, odoo doesn't sync loyalty points correctly, so user gets old data on that issue causing bugs like letting user give an unlimited amount of rewards if customer gets back several times on the same session, or being able to edit loyalty points that maybe other cashiers have updated.

Current behavior before PR:
Customers arent updated on the session, only at the beggining of the session

Desired behavior after PR is merged:
Customers updated every time the user clicks on the customer button




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
